### PR TITLE
Update reward_shop.cpp - added instant 80 as feature

### DIFF
--- a/src/reward_shop.cpp
+++ b/src/reward_shop.cpp
@@ -180,6 +180,19 @@ public:
                 player->SetAtLoginFlag(AT_LOGIN_CHANGE_RACE);
                 ChatHandler(player->GetSession()).PSendSysMessage("CHAT OUTPUT: Please log out for race change.");
                 break;
+            case 6: /* Level Up */
+                if (player->getLevel() < 80) {
+                    player->SetLevel(80);
+                    player->SetUInt32Value(PLAYER_XP, 0);
+                    player->SetUInt32Value(PLAYER_NEXT_LEVEL_XP, 0);
+                    player->SetUInt32Value(PLAYER_FIELD_MAX_LEVEL, 80);
+                    player->UpdateSkillsToMaxSkillsForLevel();
+                    ChatHandler(player->GetSession()).PSendSysMessage("CHAT OUTPUT: You´ve reached level 80.");
+                }
+                else {
+                    ChatHandler(player->GetSession()).PSendSysMessage("CHAT OUTPUT: You´re already level 80.");
+                }
+                break;
             }
 
         } while (result->NextRow());


### PR DESCRIPTION
The new  written case lines (from 182-195), it´s a new feature to this wonderful module, it gives the player the opportunity to make a code to reach instant level 80 (like blizzard store).

It also checks if the character is already 80 (if so, shows an OUTPUT)

Tested on both servers public and localhost
Azeroth.cl - No Problems
localhost - No Problems

Tested on Azure VM - No Problems

Commit Link: [Commit](https://github.com/azerothcore/mod-reward-shop/pull/27/commits/1d1a18e18ab659c73cd2c91a325528c82850bdd1)
Raw Code: [Level 80.txt](https://github.com/azerothcore/mod-reward-shop/files/11954318/Level.80.txt)